### PR TITLE
TRITON-2293 Update sdc-volapi volume image to minimal-64@20.4.0

### DIFF
--- a/sapi_manifests/volapi/template
+++ b/sapi_manifests/volapi/template
@@ -4,7 +4,7 @@
     "ufdsAdminUuid": "{{{ufds_admin_uuid}}}",
     "nfsServerImageUuid": "9fb86870-1941-11e6-8002-4f231c890ed1",
     "nfsServer2Enabled": true,
-    "nfsServerImageUuid2": "7f4d80b4-9d70-11e9-9388-6b41834cbeeb",
+    "nfsServerImageUuid2": "800db35c-5408-11eb-9792-872f658e7911",
     "api": {
         "port": 80
     },


### PR DESCRIPTION
The image itself does practically nothing. The service is really from the kernel and the platform image. Updating the image is more of a formality so that operators could potentially remove the 19.2 image from their datacenter.